### PR TITLE
Update BPS fault to read CAN 0x103 bit 0

### DIFF
--- a/include/lightingCAN.h
+++ b/include/lightingCAN.h
@@ -52,7 +52,8 @@
 #endif
 
 #ifdef BPS_FAULT
-    #define LED_ID_2 0x100
+    #define LED_ID_2 0x103
+    #define BIT_OFF2 0
     #define BLINK2 true
 #endif
 

--- a/src/lightingCAN.cpp
+++ b/src/lightingCAN.cpp
@@ -43,7 +43,7 @@ void LightingCAN::readHandler(CAN_message_t msg) {
 
 #if defined(BPS_FAULT)
     if (msg.id == LED_ID_2) {
-        leds[1].on = msg.buf[0] != 0 || msg.buf[2] != 0 || msg.buf[4] != 0 || msg.buf[5] != 0;
+        leds[1].on = (data >> BIT_OFF2) & 1;
         setLED(1);
     }
 #endif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
BPS fault was listening on CAN `0x100` and treating any of several payload bytes as active. It now follows the same single-bit pattern as the other lights:

- CAN ID: `0x100` → `0x103`
- Signal: bit 0 of byte 0 (`BIT_OFF2 = 0`)

Based on the current competition lighting board code.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7be0-eece-7895-87fc-b0e432ad76d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7be0-eece-7895-87fc-b0e432ad76d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

